### PR TITLE
Change UDPBackend to be compatible with jruby

### DIFF
--- a/lib/statue/backends/udp.rb
+++ b/lib/statue/backends/udp.rb
@@ -2,10 +2,11 @@ require 'socket'
 
 module Statue
   class UDPBackend
-    attr_reader :address
+    attr_reader :host, :port
 
     def initialize(host = nil, port = nil)
-      @address = Addrinfo.udp(host || "127.0.0.1", port || 8125)
+      @host = host
+      @port = port
     end
 
     def collect_metric(metric)
@@ -18,7 +19,10 @@ module Statue
     private
 
     def socket
-      Thread.current[:statue_socket] ||= address.connect
+      Thread.current[:statue_socket] ||= begin
+        socket = UDPSocket.new(Addrinfo.ip(host).afamily)
+        socket.connect(host, port)
+      end
     end
 
     def send_to_socket(message)

--- a/lib/statue/version.rb
+++ b/lib/statue/version.rb
@@ -1,3 +1,3 @@
 module Statue
-  VERSION = '0.2.5'
+  VERSION = '0.2.6'
 end


### PR DESCRIPTION
For some crazy reason `Addrinfo.udp(host, port)` fails with `Errno::ENOPROTOOPT` in JRuby. 