### PR TITLE
Timers/Durations should be in milliseconds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,48 @@
+## [0.3.0] - Unreleased
+
+### Feature
+
+- Extract duration measuring to `Statue::Clock` and be explicit that we are handling milliseconds.
+- `RackStatistics` queue time is now taken from `X-Request-Start` header.
+
+### Backward incompatible changes
+
+- All duration reports are now sent in milliseconds (as it should have always been). These includes:
+  - `Statue.report_duration`
+  - `RackStatistics` middleware metrics
+  - `Statue.stopwatch`
+- Removed `Statue.duration`, you should use `Statue::Clock.duration_in_ms` (which is more explicit)
+- `RackStatistics`: `request.<key>` metric was renamed to `request.<key>.runtime` to have more uniform names
+- `RackStatistics`: now sends specific counter for when your application didn't handle the exception
+- `UDPBacked`: now receives host/port named params or can be built from a string with
+  `UDPBacked.from_uri(<uri>)`
+
+## [0.2.7] - 2016-03-09
+
+## Fixes
+
+- Make UDPBacked compatible with JRuby
+
+## [0.2.4] - 2016-02-04
+
+## Features
+
+- Add support for gauges
+
+## [0.2.2] - 2016-02-02
+
+## Fixes
+
+- Allow RackStatistics to handle not integer status codes
+
+## [0.2.1] - 2016-01-07
+
+## Features
+
+- Add stopwatchs to report multiple partial times
+
 ## [0.2.0] - 2015-11-17
-### Added
+
+### Features
+
 - Add support for multithreaded applications

--- a/lib/statue/backends/udp.rb
+++ b/lib/statue/backends/udp.rb
@@ -4,7 +4,12 @@ module Statue
   class UDPBackend
     attr_reader :host, :port
 
-    def initialize(host = nil, port = nil)
+    def self.from_uri(uri)
+      uri = URI(uri)
+      new(host: uri.host, port: uri.port)
+    end
+
+    def initialize(host:, port:)
       @host = host
       @port = port
     end

--- a/lib/statue/clock.rb
+++ b/lib/statue/clock.rb
@@ -1,0 +1,16 @@
+module Statue
+  module Clock
+    extend self
+
+    def now_in_ms
+      Process.clock_gettime(Process::CLOCK_MONOTONIC) * 1_000
+    end
+
+    def duration_in_ms
+      start = now_in_ms
+      yield
+      now_in_ms - start
+    end
+
+  end
+end

--- a/lib/statue/metric.rb
+++ b/lib/statue/metric.rb
@@ -1,3 +1,5 @@
+require 'statue/clock'
+
 module Statue
   class Metric
     TYPES = {
@@ -9,6 +11,7 @@ module Statue
     }
 
     attr_accessor :type, :name, :value, :sample_rate
+    attr_reader :full_name, :type_description
 
     def self.counter(name, value = 1, **options)
       new(type: :c, value: value, name: name, **options)
@@ -19,15 +22,17 @@ module Statue
     end
 
     def self.measure(name, duration: nil, **options, &block)
-      value = duration || Statue.duration(&block)
+      value = duration || Statue::Clock.duration_in_ms(&block)
       new(type: :ms, value: value, name: name, **options)
     end
 
     def initialize(type:, name:, value:, sample_rate: 1.0)
+      @type_description = TYPES[type] or raise ArgumentError, "invalid type: #{type}"
       @type  = type
       @name  = name
       @value = value
       @sample_rate = sample_rate
+      @full_name   = Statue.namespace ? "#{Statue.namespace}.#{@name}" : @name
     end
 
     def to_s
@@ -37,15 +42,7 @@ module Statue
     end
 
     def inspect
-      "#<StatsD::Instrument::Metric #{full_name} #{TYPES[type]}(#{value})@#{sample_rate}>"
-    end
-
-    def full_name
-      if Statue.namespace
-        "#{Statue.namespace}.#{@name}"
-      else
-        @name
-      end
+      "#<StatsD::Instrument::Metric #{full_name} #{type_description}(#{value})@#{sample_rate}>"
     end
 
   end

--- a/lib/statue/rack_statistics.rb
+++ b/lib/statue/rack_statistics.rb
@@ -4,7 +4,7 @@ module Statue
   # Middleware to send metrics about rack requests
   #
   # this middleware reports metrics with the following pattern:
-  #  `request.{env['REQUEST_METHOD']}.{path_name}
+  #  `{env['REQUEST_METHOD']}.{path_name}
   #
   # where `path_name` can be configured when inserting the middleware like this:
   #   `use RackStatistics, path_name: ->(env) { ... build the path name ... }`
@@ -17,17 +17,18 @@ module Statue
   #
   # Counters:
   #
-  # * <key>.status-XXX (where XXX is the status code)
-  # * <key>.success    (on any status 2XX)
-  # * <key>.unmodified (on status 304)
-  # * <key>.redirect   (on any status 3XX)
-  # * <key>.failure    (on any status 4xx)
-  # * <key>.error      (on any status 5xx or when an exception is raised)
+  # * request.<key>.status-XXX (where XXX is the status code)
+  # * request.<key>.success    (on any status 2XX)
+  # * request.<key>.unmodified (on status 304)
+  # * request.<key>.redirect   (on any status 3XX)
+  # * request.<key>.failure    (on any status 4xx)
+  # * request.<key>.error      (on any status 5xx)
+  # * request.<key>.unhandled-exception (when an exception is raised that your application didn't handle)
   #
   # Timers (all measured from the middleware perspective):
   #
-  # * <key> (request time)
-  # * request.queue (queue time, depends on HTTP_X_QUEUE_START header)
+  # * request.<key>.runtime (request time)
+  # * request.queue (queue time, depends on HTTP_X_REQUEST_START header)
   #
   # To get accurate timers, the middleware should be as higher as
   # possible in your rack stack
@@ -35,25 +36,25 @@ module Statue
   class RackStatistics
     DEFAULT_PATH_NAME = lambda do |env|
       # Remove duplicate and trailing '/'
-      path = env['REQUEST_PATH'].squeeze('/').chomp('/')
+      path = env['PATH_INFO'].squeeze('/').chomp('/')
       if path == ''
         'root'
       else
-        # Skip leading '/'
+        # Skip leading '/' and replace statsd special characters by '-'
         env['REQUEST_PATH'][1..-1].tr('/,|', '-')
       end
     end
 
     def initialize(app, path_name: DEFAULT_PATH_NAME)
       @app = app
-      @path_name  = path_name
+      @path_name = path_name
     end
 
     def call(env)
       report_header_metrics(env)
 
       response = nil
-      duration = Statue.duration do
+      duration = Statue::Clock.duration_in_ms do
         response = @app.call(env)
       end
 
@@ -67,9 +68,9 @@ module Statue
     private
 
     def report_header_metrics(env)
-      if start_header = env['HTTP_X_QUEUE_START']
+      if start_header = (env['HTTP_X_REQUEST_START'] || env['HTTP_X_QUEUE_START'])
         queue_start = start_header[/t=([\d\.]+)/, 1].to_f
-        Statue.report_duration 'request.queue', Time.now.to_f - queue_start
+        Statue.report_duration 'request.queue', (Time.now.to_f - queue_start) * 1_000
       end
     end
 
@@ -77,14 +78,14 @@ module Statue
       metric_name = metric_name(env)
       status, _headers, _body = response
 
-      Statue.report_duration metric_name, duration
+      Statue.report_duration "#{metric_name}.runtime", duration
 
       Statue.report_increment "#{metric_name}.status-#{status}"
       Statue.report_increment "#{metric_name}.#{status_group(status)}"
     end
 
     def report_exception(env, _exception)
-      Statue.report_increment "#{metric_name(env)}.error"
+      Statue.report_increment "#{metric_name(env)}.unhandled-exception"
     end
 
     def metric_name(env)

--- a/lib/statue/stopwatch.rb
+++ b/lib/statue/stopwatch.rb
@@ -1,19 +1,19 @@
 module Statue
   class Stopwatch
 
-    def initialize(name:, now: clock_now, reporter: Statue)
+    def initialize(name:, now: Clock.now_in_ms, reporter: Statue)
       @reporter = reporter
       @name     = name
       @start    = @partial = now
     end
 
-    def partial(suffix = nil, now: clock_now, **options)
+    def partial(suffix = nil, now: Clock.now_in_ms, **options)
       previous, @partial = @partial, now
 
       @reporter.report_duration(metric_name(suffix || "runtime.partial"), @partial - previous, **options)
     end
 
-    def stop(suffix = nil, now: clock_now, report_partial: false, **options)
+    def stop(suffix = nil, now: Clock.now_in_ms, report_partial: false, **options)
       partial(report_partial.is_a?(String) ? report_partial : nil, now: now, **options) if report_partial
 
       previous, @start = @start, now
@@ -21,7 +21,7 @@ module Statue
       @reporter.report_duration(metric_name(suffix || "runtime.total"), @start - previous, **options)
     end
 
-    def reset(now: clock_now)
+    def reset(now: Clock.now_in_ms)
       @start = @partial = now
     end
 
@@ -29,10 +29,6 @@ module Statue
 
     def metric_name(suffix)
       "#{@name}.#{suffix}"
-    end
-
-    def clock_now
-      Process.clock_gettime(Process::CLOCK_MONOTONIC)
     end
 
   end

--- a/lib/statue/version.rb
+++ b/lib/statue/version.rb
@@ -1,3 +1,3 @@
 module Statue
-  VERSION = '0.2.7'
+  VERSION = '0.3.0'
 end

--- a/statue.gemspec
+++ b/statue.gemspec
@@ -19,5 +19,7 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency "bundler", "~> 1.7"
   spec.add_development_dependency "rake", "~> 10.0"
+  spec.add_development_dependency "rack", "~> 1.6"
+  spec.add_development_dependency "rack-test", "~> 0.6.3"
   spec.add_development_dependency "minitest"
 end

--- a/test/rack_statistics_test.rb
+++ b/test/rack_statistics_test.rb
@@ -1,0 +1,140 @@
+require 'test_helper'
+require 'statue/rack_statistics'
+require 'rack/test'
+
+describe Statue::RackStatistics do
+  include Rack::Test::Methods
+  def app
+    Statue::RackStatistics.new(App.new)
+  end
+
+  def find_metric(name)
+    Statue.backend.captures.find { |m| m.name == name }
+  end
+
+  class App
+    def call(env)
+      raise "Uncaught error" if env['raise_error']
+      [
+        env['status'] || 200,
+        {},
+        []
+      ]
+    end
+  end
+
+  after do
+    Statue.backend.captures.clear
+  end
+
+  describe "request statistics on normal processing" do
+
+    it "sends queue time" do
+      header "X-Request-Start", "t=#{Time.now.to_f - 1}"
+      get "/"
+
+      queue_time = find_metric("request.queue")
+      assert queue_time, "Didn't report queue time"
+      assert_equal "measure", queue_time.type_description
+
+      # Measured time can't be less than 1000 ms because we set it to 1 sec before now.
+      # Allow a range of 30ms for ruby to do processing and avoid false positives
+      assert_in_delta 1015, queue_time.value, 15 # within range 1000-1030
+    end
+
+    it "sends request runtime" do
+      get "/"
+
+      runtime_time = find_metric("request.GET.root.runtime")
+      assert runtime_time, "Didn't report request runtime"
+      assert_equal "measure", runtime_time.type_description
+      # Allow a range of 30ms for ruby to do processing and avoid false positives
+      assert_in_delta 15, runtime_time.value, 15 # within range 1000-1030
+    end
+
+    it "sends counter for status-xxx" do
+      get "/"
+
+      runtime_time = find_metric("request.GET.root.status-200")
+      assert runtime_time, "Didn't report status-200 counter"
+      assert_equal "increment", runtime_time.type_description
+      assert_equal 1, runtime_time.value
+    end
+
+    it "sends counter for status group" do
+      get "/"
+
+      runtime_time = find_metric("request.GET.root.success")
+      assert runtime_time, "Didn't report sucess counter"
+      assert_equal "increment", runtime_time.type_description
+      assert_equal 1, runtime_time.value
+    end
+
+    it "sends counter for other status codes" do
+      get "/", {}, { 'status' => 502 }
+
+      runtime_time = find_metric("request.GET.root.status-502")
+      assert runtime_time, "Didn't report status-502 counter"
+      assert_equal "increment", runtime_time.type_description
+      assert_equal 1, runtime_time.value
+    end
+
+    it "sends counter for other status groups" do
+      get "/", {}, { 'status' => 502 }
+
+      runtime_time = find_metric("request.GET.root.error")
+      assert runtime_time, "Didn't report error counter"
+      assert_equal "increment", runtime_time.type_description
+      assert_equal 1, runtime_time.value
+    end
+
+    it "sends all metrics and only those" do
+      header "X-Request-Start", "t=#{Time.now.to_f}"
+      get "/"
+
+      metrics = Statue.backend.captures.map(&:name)
+      expected_metrics = %w[
+        request.queue
+        request.GET.root.runtime
+        request.GET.root.status-200
+        request.GET.root.success
+      ]
+      missing = expected_metrics - metrics
+      extra   = metrics - expected_metrics
+
+      assert missing.empty?, "expect not to be missing, but these were missing: #{missing.inspect}"
+      assert extra.empty?, "expected no other metric to be found, but found these: #{extra.inspect}"
+    end
+
+  end
+
+  describe "request statistics on normal processing" do
+
+    it "sends queue time" do
+      header "X-Request-Start", "t=#{Time.now.to_f - 1}"
+      assert_raises do
+        get "/", {}, { 'raise_error' => true }
+      end
+
+      queue_time = find_metric("request.queue")
+      assert queue_time, "Didn't report queue time"
+      assert_equal "measure", queue_time.type_description
+
+      # Measured time can't be less than 1000 ms because we set it to 1 sec before now.
+      # Allow a range of 30ms for ruby to do processing and avoid false positives
+      assert_in_delta 1015, queue_time.value, 15 # within range 1000-1030
+    end
+
+    it "sends counter for other status codes" do
+      assert_raises do
+        get "/", {}, { 'raise_error' => true }
+      end
+
+      runtime_time = find_metric("request.GET.root.unhandled-exception")
+      assert runtime_time, "Didn't report unhandled-exception counter"
+      assert_equal "increment", runtime_time.type_description
+      assert_equal 1, runtime_time.value
+    end
+
+  end
+end

--- a/test/statue_test.rb
+++ b/test/statue_test.rb
@@ -39,7 +39,7 @@ describe Statue do
     end
 
     it "adds a measure metric to the backend using the fixed value" do
-      result = Statue.report_duration("some.timer", 2.5)
+      _result = Statue.report_duration("some.timer", 2.5)
 
       assert_equal 1, Statue.backend.captures.size
       assert_equal "some.timer:2.5|ms", Statue.backend.captures.first.to_s
@@ -59,7 +59,7 @@ describe Statue do
   describe ".report_gauge" do
 
     it "adds a gauge metric to the backend using the fixed value" do
-      result = Statue.report_gauge("some.gauge", 23)
+      _result = Statue.report_gauge("some.gauge", 23)
 
       assert_equal 1, Statue.backend.captures.size
       assert_equal "some.gauge:23|g", Statue.backend.captures.first.to_s

--- a/test/statue_test.rb
+++ b/test/statue_test.rb
@@ -24,8 +24,8 @@ describe Statue do
   describe ".report_duration" do
 
     it "adds a measure metric to the backend using the block call duration" do
-      Statue.stub(:duration, 1.5) do
-        result = Statue.report_duration("some.timer") { nil }
+      Statue::Clock.stub(:duration_in_ms, 1.5) do
+        _result = Statue.report_duration("some.timer") { nil }
 
         assert_equal 1, Statue.backend.captures.size
         assert_equal "some.timer:1.5|ms", Statue.backend.captures.first.to_s

--- a/test/stopwatch_test.rb
+++ b/test/stopwatch_test.rb
@@ -8,7 +8,7 @@ describe Statue::Stopwatch do
   describe "#partial" do
     it "reports the duration between start and the partial call" do
       stopwatch = Statue::Stopwatch.new(name: "my_watch", now: 0)
-      stopwatch.partial(now: 42)
+      stopwatch.partial(now: 42) # 42 milliseconds after
 
       assert_equal 1, Statue.backend.captures.size
       assert_equal "my_watch.runtime.partial:42|ms", Statue.backend.captures.first.to_s
@@ -47,7 +47,7 @@ describe Statue::Stopwatch do
       stopwatch.stop(now: 21)
 
       assert_equal 21, Statue.backend.captures.size
-      *partials, total = Statue.backend.captures
+      *_partials, total = Statue.backend.captures
       assert_equal "my_watch.runtime.total:21|ms", total.to_s
     end
 
@@ -70,7 +70,7 @@ describe Statue::Stopwatch do
       stopwatch.stop(now: 21, report_partial: "runtime.final_lap")
 
       assert_equal 22, Statue.backend.captures.size
-      *partials, special_partial, total = Statue.backend.captures
+      *_partials, special_partial, _total = Statue.backend.captures
       assert_equal "my_watch.runtime.final_lap:1|ms", special_partial.to_s
     end
 


### PR DESCRIPTION
StatsD protocol says measures should be in millisecond but we were sending seconds.
Also, as we are doing a major change, took the time for also improving some names and other backward incompatible changes. See CHANGELOG.